### PR TITLE
DRAFT for Road-Rally OpenRally GPX

### DIFF
--- a/road-rally/example.gpx
+++ b/road-rally/example.gpx
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="YOUR APPLICATION NAME HERE" version="1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:openrally="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3-DRAFT" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd
+                      http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3-DRAFT openrally.xsd">
+
+  <metadata>
+    <extensions>
+      <openrally:type>rally</openrally:type>
+      <openrally:units>metric</openrally:units>
+      <openrally:distance>33.86</openrally:distance>
+    </extensions>
+  </metadata>
+
+  <!-- minimum <wpt> must have a distance -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.0</openrally:distance>
+    </extensions>
+  </wpt>
+
+  <!-- TC -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.01</openrally:distance>
+      <openrally:timecontrol activate="50" clear="10" name="TC0"/>
+    </extensions>
+  </wpt>
+
+  <!-- Start -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.1</openrally:distance>
+      <openrally:ss activate="50" clear="10" name="SS1"/>
+    </extensions>
+  </wpt>
+
+  <!-- radio point + medical + police-->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.2</openrally:distance>
+      <openrally:radio/>
+      <openrally:medical/>
+      <openrally:police/>
+    </extensions>
+  </wpt>
+
+  <!-- chicane -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.3</openrally:distance>
+      <openrally:chicane/>
+      <openrally:chicane_type>single</openrally:chicane_type>
+      <openrally:chicane_entry>left</openrally:chicane_entry>
+    </extensions>
+  </wpt>
+
+  <!-- virtual chicane -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.4</openrally:distance>
+      <openrally:vc_in/>
+      <openrally:speed>50</openrally:speed>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.5</openrally:distance>
+      <openrally:vc_end/>
+      <openrally:ez/>
+    </extensions>
+  </wpt>
+
+   <!-- slow zone -->
+   <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.6</openrally:distance>
+      <openrally:sz_in/>
+      <openrally:speed>70</openrally:speed>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.7</openrally:distance>
+      <openrally:sz_end/>
+      <openrally:ez/>
+    </extensions>
+  </wpt>
+
+  <!-- service area -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.71</openrally:distance>
+      <openrally:service/>
+    </extensions>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.79</openrally:distance>
+      <openrally:ez/>
+    </extensions>
+  </wpt>
+
+  <!-- Tulip and Notes drawings -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.8</openrally:distance>
+      <!-- PNG only -->
+      <openrally:tulip><![CDATA[
+          data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXAAAADiCAYAAABXwJzDAAAAAXNSR0IArs4c6QAACmhJREFUeAHt3UuO5FQQBdBuFsCArSA2wyJ6BSyKASP2xBSGRVr00y0VZefPv1t1Uko5sLPsyBOpqxAS4ssXLwIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBD4n8CPlzPT24vAhxT44UN+K1+KwH8C3y6H6e1FgAABAkUC0+b91/e3LbxocFolQIDAbxeCl+/vqfYiQIAAgQKBsX2PAJ82cVt4weC0SIAAgdfb9whxW7jfBQECBE4u8Hb7HgFuCz/54LRHgACB97bvEeK2cL8PAgQInFRgbvseAW4LP+ngtEWAAIGl7XuEuC3c74QAAQInE7i2fY8At4WfbHDaeVzAf4n5uJ2/PJfAt0s7P93Q0vSZ6bNeBAgQIHACgVu3b1v4CYalhfUEbODrWbrTcQK3bt+jQ1v4kHAkQIDAgQL3bt+28AOH5dHrCtjA1/V0t/0F7t2+R4e28CHhSIAAgQMEHt2+beEHDMsj1xewga9v6o77CTy6fY8ObeFDwpEAAQI7Cjy7fdvCdxyWR20jYAPfxtVdtxd4dvseHdrCh4QjAQIEdhBYa/u2he8wLI/YTsAGvp2tO28nsNb2PTq0hQ8JRwIECGwosPb2bQvfcFhuva2ADXxbX3dfX2Dt7Xt0aAsfEo4ECBDYQGCr7dsWvsGw3HJ7ARv49saesJ7AVtv36NAWPiQcCRAgsKLA1tu3LXzFYbnVPgI28H2cPeV5ga2379GhLXxIOBIgQGAFgb22b1v4CsNyi/0EbOD7WXvS4wJ7bd+jQ1v4kHAkQIDAEwJ7b9+28CeG5U/3FbCB7+vtafcL7L19jw5t4UPCkQABAg8IHLV928IfGJY/2V/ABr6/uSfeLnDU9j06tIUPCUcCBAjcIXD09m0Lv2NYPnqMgA38GHdPvS5w9PY9OrSFDwlHAgQI3CBwlu3bFn7DsHzkOAEb+HH2njwvcJbte3RoCx8SjgQIEFgQONv2bQtfGJZLxwp8Pfbxnk5gdYEpcJdefvNLOq5VCfhXKFXj0iwBAgQiIMBjoSJAgECVgACvGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LswQIEIiAAI+FigABAlUCArxqXJolQIBABAR4LFQECBCoEhDgVePSLAECBCIgwGOhIkCAQJWAAK8al2YJECAQAQEeCxUBAgSqBAR41bg0S4AAgQgI8FioCBAgUCUgwKvGpVkCBAhEQIDHQkWAAIEqAQFeNS7NEiBAIAICPBYqAgQIVAkI8KpxaZYAAQIREOCxUBEgQKBKQIBXjUuzBAgQiIAAj4WKAAECVQICvGpcmiVAgEAEBHgsVAQIEKgSEOBV49IsAQIEIiDAY6EiQIBAlYAArxqXZgkQIBABAR4LFQECBKoEBHjVuDRLgACBCAjwWKgIECBQJSDAq8alWQIECERAgMdCRYAAgSoBAV41Ls0SIEAgAgI8FioCBAhUCQjwqnFplgABAhEQ4LFQESBAoEpAgFeNS7MECBCIgACPhYoAAQJVAgK8alyaJUCAQAQEeCxUBAgQqBIQ4FXj0iwBAgQiIMBjoSJAgECVgACvGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LswQIEIiAAI+FigABAlUCArxqXJolQIBABAR4LFQECBCoEhDgVePSLAECBCIgwGOhIkCAQJWAAK8al2YJECAQAQEeCxUBAgSqBAR41bg0S4AAgQgI8FioCBAgUCUgwKvGpVkCBAhEQIDHQkWAAIEqAQFeNS7NEiBAIAICPBYqAgQIVAkI8KpxaZYAAQIREOCxUBEgQKBKQIBXjUuzBAgQiIAAj4WKAAECVQICvGpcmiVAgEAEBHgsVJ9D4JfP8TV9SwIECPQJvFxaXnr/cbkuxPvmqmMCBD6BwFJ4j2tC/BP8EHxFAgT6BEZIzx2n8J6uCfG+2eqYAIEPLjAX3OP89K9PhPgH/xH4egQIdAqMoJ47Tt9KiHfOVtcECHxwgbngHufH1xfiQ8KRAAECJxEYQT13fN2mEH+toSZAgMDBAnPBPc6/bU+IvxXxzwQIEDhIYAT13PG9toT4eyrOESBAYGeBueAe5+faEeJzMs4TIEBgJ4ER1HPHpTaE+JKOawQIENhYYC64x/lrjxfi14RcJ0CAwEYCI6jnjrc8VojfouQzBAgQWFlgLrjH+VsfJ8RvlfI5AgQIrCQwgnrueM9jhPg9Wj5LgACBJwXmgnucv/f2QvxeMZ8nQIDAgwIjqOeOj9z2dYj/+sgN/A0BAgQIXBeYC+5x/vod3v/EFOLC+30bZw8S+HrQcz2WwFYCU1Avvfzml3RcqxLw/8SsGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LswQIEIiAAI+FigABAlUCArxqXJolQIBABAR4LFQECBCoEhDgVePSLAECBCIgwGOhIkCAQJWAAK8al2YJECAQAQEeCxUBAgSqBAR41bg0S4AAgQgI8FioCBAgUCUgwKvGpVkCBAhEQIDHQkWAAIEqAQFeNS7NEiBAIAICPBYqAgQIVAkI8KpxaZYAAQIREOCxUBEgQKBKQIBXjUuzBAgQiIAAj4WKAAECVQICvGpcmiVAgEAEBHgsVAQIEKgSEOBV49IsAQIEIiDAY6EiQIBAlYAArxqXZgkQIBABAR4LFQECBKoEBHjVuDRLgACBCAjwWKgIECBQJSDAq8alWQIECERAgMdCRYAAgSoBAV41Ls0SIEAgAgI8FioCBAhUCQjwqnFplgABAhEQ4LFQESBAoEpAgFeNS7MECBCIgACPhYoAAQJVAgK8alyaJUCAQAQEeCxUBAgQqBIQ4FXj0iwBAgQiIMBjoSJAgECVgACvGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LszcI/LPwmaVrC3/mEoFzCgjwc85FV48L/Lnwp0vXFv7MJQIECBDYQ+Dny0P+vrxf3rync9M1LwIECBA4scAU1L9f3lNoT++pFt4XBC8CBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQILC2wL/1CW3p84Yg8QAAAABJRU5ErkJggg==
+        ]]>      </openrally:tulip>
+      <!-- PNG wrapped in SVG -->
+      <openrally:notes><![CDATA[
+        <svg>
+          <img href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXAAAADiCAYAAABXwJzDAAAAAXNSR0IArs4c6QAACmhJREFUeAHt3UuO5FQQBdBuFsCArSA2wyJ6BSyKASP2xBSGRVr00y0VZefPv1t1Uko5sLPsyBOpqxAS4ssXLwIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBD4n8CPlzPT24vAhxT44UN+K1+KwH8C3y6H6e1FgAABAkUC0+b91/e3LbxocFolQIDAbxeCl+/vqfYiQIAAgQKBsX2PAJ82cVt4weC0SIAAgdfb9whxW7jfBQECBE4u8Hb7HgFuCz/54LRHgACB97bvEeK2cL8PAgQInFRgbvseAW4LP+ngtEWAAIGl7XuEuC3c74QAAQInE7i2fY8At4WfbHDaeVzAf4n5uJ2/PJfAt0s7P93Q0vSZ6bNeBAgQIHACgVu3b1v4CYalhfUEbODrWbrTcQK3bt+jQ1v4kHAkQIDAgQL3bt+28AOH5dHrCtjA1/V0t/0F7t2+R4e28CHhSIAAgQMEHt2+beEHDMsj1xewga9v6o77CTy6fY8ObeFDwpEAAQI7Cjy7fdvCdxyWR20jYAPfxtVdtxd4dvseHdrCh4QjAQIEdhBYa/u2he8wLI/YTsAGvp2tO28nsNb2PTq0hQ8JRwIECGwosPb2bQvfcFhuva2ADXxbX3dfX2Dt7Xt0aAsfEo4ECBDYQGCr7dsWvsGw3HJ7ARv49saesJ7AVtv36NAWPiQcCRAgsKLA1tu3LXzFYbnVPgI28H2cPeV5ga2379GhLXxIOBIgQGAFgb22b1v4CsNyi/0EbOD7WXvS4wJ7bd+jQ1v4kHAkQIDAEwJ7b9+28CeG5U/3FbCB7+vtafcL7L19jw5t4UPCkQABAg8IHLV928IfGJY/2V/ABr6/uSfeLnDU9j06tIUPCUcCBAjcIXD09m0Lv2NYPnqMgA38GHdPvS5w9PY9OrSFDwlHAgQI3CBwlu3bFn7DsHzkOAEb+HH2njwvcJbte3RoCx8SjgQIEFgQONv2bQtfGJZLxwp8Pfbxnk5gdYEpcJdefvNLOq5VCfhXKFXj0iwBAgQiIMBjoSJAgECVgACvGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LswQIEIiAAI+FigABAlUCArxqXJolQIBABAR4LFQECBCoEhDgVePSLAECBCIgwGOhIkCAQJWAAK8al2YJECAQAQEeCxUBAgSqBAR41bg0S4AAgQgI8FioCBAgUCUgwKvGpVkCBAhEQIDHQkWAAIEqAQFeNS7NEiBAIAICPBYqAgQIVAkI8KpxaZYAAQIREOCxUBEgQKBKQIBXjUuzBAgQiIAAj4WKAAECVQICvGpcmiVAgEAEBHgsVAQIEKgSEOBV49IsAQIEIiDAY6EiQIBAlYAArxqXZgkQIBABAR4LFQECBKoEBHjVuDRLgACBCAjwWKgIECBQJSDAq8alWQIECERAgMdCRYAAgSoBAV41Ls0SIEAgAgI8FioCBAhUCQjwqnFplgABAhEQ4LFQESBAoEpAgFeNS7MECBCIgACPhYoAAQJVAgK8alyaJUCAQAQEeCxUBAgQqBIQ4FXj0iwBAgQiIMBjoSJAgECVgACvGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LswQIEIiAAI+FigABAlUCArxqXJolQIBABAR4LFQECBCoEhDgVePSLAECBCIgwGOhIkCAQJWAAK8al2YJECAQAQEeCxUBAgSqBAR41bg0S4AAgQgI8FioCBAgUCUgwKvGpVkCBAhEQIDHQkWAAIEqAQFeNS7NEiBAIAICPBYqAgQIVAkI8KpxaZYAAQIREOCxUBEgQKBKQIBXjUuzBAgQiIAAj4WKAAECVQICvGpcmiVAgEAEBHgsVJ9D4JfP8TV9SwIECPQJvFxaXnr/cbkuxPvmqmMCBD6BwFJ4j2tC/BP8EHxFAgT6BEZIzx2n8J6uCfG+2eqYAIEPLjAX3OP89K9PhPgH/xH4egQIdAqMoJ47Tt9KiHfOVtcECHxwgbngHufH1xfiQ8KRAAECJxEYQT13fN2mEH+toSZAgMDBAnPBPc6/bU+IvxXxzwQIEDhIYAT13PG9toT4eyrOESBAYGeBueAe5+faEeJzMs4TIEBgJ4ER1HPHpTaE+JKOawQIENhYYC64x/lrjxfi14RcJ0CAwEYCI6jnjrc8VojfouQzBAgQWFlgLrjH+VsfJ8RvlfI5AgQIrCQwgnrueM9jhPg9Wj5LgACBJwXmgnucv/f2QvxeMZ8nQIDAgwIjqOeOj9z2dYj/+sgN/A0BAgQIXBeYC+5x/vod3v/EFOLC+30bZw8S+HrQcz2WwFYCU1Avvfzml3RcqxLw/8SsGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LswQIEIiAAI+FigABAlUCArxqXJolQIBABAR4LFQECBCoEhDgVePSLAECBCIgwGOhIkCAQJWAAK8al2YJECAQAQEeCxUBAgSqBAR41bg0S4AAgQgI8FioCBAgUCUgwKvGpVkCBAhEQIDHQkWAAIEqAQFeNS7NEiBAIAICPBYqAgQIVAkI8KpxaZYAAQIREOCxUBEgQKBKQIBXjUuzBAgQiIAAj4WKAAECVQICvGpcmiVAgEAEBHgsVAQIEKgSEOBV49IsAQIEIiDAY6EiQIBAlYAArxqXZgkQIBABAR4LFQECBKoEBHjVuDRLgACBCAjwWKgIECBQJSDAq8alWQIECERAgMdCRYAAgSoBAV41Ls0SIEAgAgI8FioCBAhUCQjwqnFplgABAhEQ4LFQESBAoEpAgFeNS7MECBCIgACPhYoAAQJVAgK8alyaJUCAQAQEeCxUBAgQqBIQ4FXj0iwBAgQiIMBjoSJAgECVgACvGpdmCRAgEAEBHgsVAQIEqgQEeNW4NEuAAIEICPBYqAgQIFAlIMCrxqVZAgQIRECAx0JFgACBKgEBXjUuzRIgQCACAjwWKgIECFQJCPCqcWmWAAECERDgsVARIECgSkCAV41LszcI/LPwmaVrC3/mEoFzCgjwc85FV48L/Lnwp0vXFv7MJQIECBDYQ+Dny0P+vrxf3rync9M1LwIECBA4scAU1L9f3lNoT++pFt4XBC8CBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQIECAAAECBAgQILC2wL/1CW3p84Yg8QAAAABJRU5ErkJggg=="/>
+        </svg>
+        ]]>      </openrally:notes>
+    </extensions>
+  </wpt>
+
+  <!-- Tulip and Notes drawings -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>0.9</openrally:distance>
+      <!-- Full SVG -->
+      <openrally:tulip><![CDATA[
+        <svg>
+          <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+        </svg>
+        ]]>      </openrally:tulip>
+      <openrally:notes><![CDATA[
+        <svg>
+          <text>SVG Example</text>
+        </svg>
+        ]]>      </openrally:notes>
+    </extensions>
+  </wpt>
+
+  <!-- Flying Finish -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>1.0</openrally:distance>
+      <openrally:ff name="FF1"/>
+    </extensions>
+  </wpt>
+
+  <!-- Stop Finish -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>1.2</openrally:distance>
+      <openrally:stop_control/>
+    </extensions>
+  </wpt>
+
+  <!-- or any other tags (using them all at once is nonsensical) -->
+  <wpt lat="0" lon="0">
+    <extensions>
+      <openrally:distance>1.23</openrally:distance>
+      <openrally:show_coordinates/>
+      <openrally:gsm_strength/>
+      <openrally:reset/>
+      <!-- reset odo to 0.00 -->
+      <openrally:timecontrol activate="50" clear="10" name="TC99"/>
+      <!-- test with no time requirement -->
+      <openrally:timecontrol activate="50" clear="10" name="TC99" allowed="80"/>
+      <openrally:ss activate="50" clear="10" name="SS1"/>
+      <openrally:service/>
+      <openrally:tyre_marking/>
+      <openrally:refuel/>
+      <openrally:TWZ activate="10" clear="10"/>
+      <openrally:TWZ_end activate="500" clear="30"/>
+      <openrally:HEV/>
+      <openrally:HEV_refuge/>
+      <openrally:media/>
+      <openrally:ez activate="10" clear="10"/>
+      <openrally:radio name="R999"/>
+      <openrally:medical name="A999"/>
+      <openrally:checkpoint activate="50" clear="10" name="CP99"/>
+      <openrally:chicane activate="300" clear="20"/>
+      <openrally:chicane_type>single</openrally:chicane_type>
+      <openrally:chicane_entry>left</openrally:chicane_entry>
+      <openrally:vc_in activate="300" clear="20"/>
+      <openrally:speed>50</openrally:speed>
+      <openrally:vc_end activate="250" clear="20"/>
+      <openrally:sz_in activate="300" clear="20"/>
+      <openrally:speed>50</openrally:speed>
+      <openrally:sz_end activate="500" clear="20"/>
+      <openrally:marshal name="M999"/>
+      <openrally:police/>
+      <openrally:fire/>
+      <openrally:technical/>
+      <openrally:recovery/>
+      <openrally:spectators/>
+      <openrally:prohibited_area/>
+      <openrally:service_park/>
+      <openrally:parking/>
+      <openrally:helicopter/>
+      <openrally:ff activate="100" clear="50" name="FF1"/>
+      <openrally:stop_control activate="200" clear="10"/>
+    </extensions>
+  </wpt>
+</gpx>

--- a/road-rally/openrally.xsd
+++ b/road-rally/openrally.xsd
@@ -1,0 +1,209 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3-DRAFT"
+  xmlns:svg="http://www.w3.org/2000/svg" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3-DRAFT">
+
+  <xs:element name="type" type="roadbookType"></xs:element>
+  <!-- NEW: The type of the roadbook: cross-country, rally, regularity -->
+  <xs:element name="units" type="unitsType">
+  <!-- The valid "units" are "metric" or "statute". Under "metric", route distances are in kilometers, speeds are in kph, and waypoint radii are in meters. Under the "statute" measurement system, route distances are in statute miles, speeds are in mph, and waypoint radii are in yards. -->
+  </xs:element>
+  <xs:element name="distance" type="distanceType"/>
+  <!-- start/finish -->
+  <xs:element name="ss" type="waypointType"/>
+  <xs:element name="ff" type="waypointType"/>
+  <xs:element name="stop_control" type="waypointType"/>
+  <!-- drawing elements -->
+  <xs:element name="tulip" type="drawingType"/>
+  <xs:element name="notes" type="drawingType"/>
+  <!-- other control points -->
+  <xs:element name="checkpoint" type="waypointType"/>
+  <xs:element name="timecontrol" type="timeLimitType"/>
+  <xs:element name="reset" type="distanceType" default="0"/>
+
+  <!-- Instruct consumer to allow display of GPS coords for this WPT -->
+  <xs:element name="show_coordinates" type="markerType"/>
+  
+  <!-- GSM signal bars -->
+  <xs:element name="gsm_strength" type="markerType"/>
+
+  <!-- Tyre warming zone -->
+  <xs:element name="TWZ" type="waypointType"/>
+  <xs:element name="TWZ_end" type="waypointType"/>
+  <xs:element name="ez" type="waypointType"/>
+  <!-- Chicane -->
+  <xs:element name="chicane" type="waypointType"/>
+  <xs:element name="chicane_type" type="chicaneType"/>
+  <xs:element name="chicane_entry" type="chicaneEntryType"/>
+  <xs:element name="vc_in" type="waypointType"/>
+  <xs:element name="vc_end" type="waypointType"/>
+  <!-- Slow zone -->
+  <xs:element name="sz_in" type="waypointType"/>
+  <xs:element name="speed" type="speedType"/>
+  <xs:element name="sz_end" type="waypointType"/>
+
+  <!--
+  safety tags, primarily used in an organiser's mapping/tracking to locate
+  assets on the course.
+  -->
+  <!-- named ones -->
+  <xs:element name="radio" type="namedType"/>
+  <xs:element name="medical" type="namedType"/>
+  <xs:element name="marshal" type="namedType"/>
+
+  <!-- markers only -->
+  <xs:element name="service" type="markerType"/>
+  <xs:element name="tyre_marking" type="markerType"/>
+  <xs:element name="refuel" type="markerType"/>
+  <xs:element name="HEV" type="markerType"/>
+  <xs:element name="HEV_refuge" type="markerType"/>
+  <xs:element name="media" type="markerType"/>
+  <xs:element name="police" type="markerType"/>
+  <xs:element name="fire" type="markerType"/>
+  <xs:element name="technical" type="markerType"/>
+  <xs:element name="recovery" type="markerType"/>
+  <xs:element name="spectators" type="markerType"/>
+  <xs:element name="prohibited_area" type="markerType"/>
+  <xs:element name="service_park" type="markerType"/>
+  <xs:element name="parking" type="markerType"/>
+  <xs:element name="helicopter" type="markerType"/> 
+
+  <!-- data types -->
+
+  <xs:simpleType name="chicaneType">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="single"/>
+      <xs:enumeration value="double"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="chicaneEntryType">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="waypointType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name"/>
+        <xs:attribute type="xs:positiveInteger" name="activate"/>
+        <xs:attribute type="xs:positiveInteger" name="clear"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="namedType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:simpleType name="roadbookType">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="cross-country"/>
+      <xs:enumeration value="rally"/>
+      <xs:enumeration value="regularity"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="unitsType">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="metric"/>
+      <xs:enumeration value="statue"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="markerType">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="distanceType">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="timeLimitType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:positiveInteger" name="activate">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              Distance to yellow sign.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="xs:positiveInteger" name="clear">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              Validation radius of the waypoint.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="xs:string" name="name">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              Name of the timecontrol.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="xs:integer" name="allowed">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              Number of minutes allowed to get from THIS timecontrol to the NEXT timecontrol.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:simpleType name="timeType">
+    <!-- time in seconds -->
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="speedType">
+    <xs:restriction base="xs:positiveInteger">
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="drawingType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="href"/>
+        <xs:attribute type="xs:string" name="id"/>
+      </xs:extension>
+      <!--
+      May contain either an SVG or a base64 encoded dataUrl.
+
+      The data *should* be wrapped in CDATA so that parsers can optionally
+      ignore the overhead of parsing. Not all apps consuming the openrally
+      file will have rendering responsibility.
+
+      SVG *should not* reference external hrefs. That defeats the point of
+      having everything in one complete file. Access to internet may well not
+      be possible at the time and place the GPX is loaded/parsed.
+
+      Example (raster of a single transparent pixel):
+      <o:tulip><![CDATA[data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==]]></o:tulip>
+
+      Example (SVG):
+      <o:tulip>
+<![CDATA[
+          <svg width="100" height="100"><circle cx="50" cy="47" r="30" stroke="red" stroke-width="3" fill="none"/></svg>
+        ]]>
+</o:tulip>
+      -->
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/road-rally/test_wrapper.xsd
+++ b/road-rally/test_wrapper.xsd
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema elementFormDefault="qualified"
+    xmlns="http://www.w3.org/2001/XMLSchema">
+    <import namespace="http://www.openrally.org/xmlschemas/GpxExtensions/v1.0.3-DRAFT" schemaLocation="openrally.xsd"/>
+    <import namespace="http://www.topografix.com/GPX/1/1" schemaLocation="../common/gpx-strict.xsd"/>
+</schema>

--- a/road-rally/validate.sh
+++ b/road-rally/validate.sh
@@ -1,0 +1,4 @@
+xmllint --noout --schema ../common/XMLSchema.xsd openrally.xsd
+xmllint --noout --schema ../common/XMLSchema.xsd ../common/gpx-strict.xsd
+xmllint --noout --schema ../common/XMLSchema.xsd test_wrapper.xsd
+xmllint --noout --schema test_wrapper.xsd example.gpx


### PR DESCRIPTION
Proposal for a modern Road-Rally GPX standard. As far as I know, the old v0.3-DRAFT is not in active use, so I used the current v1.0.2 Cross-Country format as a source and modified it to fit the 2025 FIA Regional Rally Sporting Regulations. I added Waypoints for Chicane, Virtual Chicane (VC), and Slow Zone (SZ). This format differs from the Cross-Country format, so I added an openrally:type tag to differentiate between them.